### PR TITLE
Replace id usage with _id

### DIFF
--- a/src/plugins/audit-log.ts
+++ b/src/plugins/audit-log.ts
@@ -42,7 +42,7 @@ export class AuditLogPlugin implements Plugin {
     
     async onAfterInsert(context: PluginContext): Promise<void> {
         if (this.options.logInserts) {
-            const id = context.result?.id || 'unknown';
+            const id = context.result?._id ?? context.result?.id ?? 'unknown';
             this.options.customLogger(
                 this.options.logLevel,
                 `Document inserted: ${context.collectionName}:${id}`,
@@ -53,7 +53,7 @@ export class AuditLogPlugin implements Plugin {
     
     async onAfterUpdate(context: PluginContext): Promise<void> {
         if (this.options.logUpdates) {
-            const id = context.result?.id || context.data?.id || 'unknown';
+            const id = context.result?._id ?? context.result?.id ?? context.data?._id ?? context.data?.id ?? 'unknown';
             this.options.customLogger(
                 this.options.logLevel,
                 `Document updated: ${context.collectionName}:${id}`,
@@ -64,7 +64,7 @@ export class AuditLogPlugin implements Plugin {
     
     async onAfterDelete(context: PluginContext): Promise<void> {
         if (this.options.logDeletes) {
-            const id = context.data?.id || 'unknown';
+            const id = context.data?._id ?? context.data?.id ?? 'unknown';
             this.options.customLogger(
                 this.options.logLevel,
                 `Document deleted: ${context.collectionName}:${id}`,

--- a/src/plugins/cache.ts
+++ b/src/plugins/cache.ts
@@ -63,8 +63,8 @@ export class CachePlugin implements Plugin {
     }
     
     async onAfterInsert(context: PluginContext): Promise<void> {
-        if (this.options.enableDocumentCache && context.result?.id) {
-            const key = this.getCacheKey(context, context.result.id);
+        if (this.options.enableDocumentCache && (context.result?._id || context.result?.id)) {
+            const key = this.getCacheKey(context, context.result._id ?? context.result.id);
             this.documentCache.set(key, {
                 value: context.result,
                 timestamp: Date.now(),
@@ -75,8 +75,8 @@ export class CachePlugin implements Plugin {
     }
     
     async onAfterUpdate(context: PluginContext): Promise<void> {
-        if (this.options.enableDocumentCache && context.result?.id) {
-            const key = this.getCacheKey(context, context.result.id);
+        if (this.options.enableDocumentCache && (context.result?._id || context.result?.id)) {
+            const key = this.getCacheKey(context, context.result._id ?? context.result.id);
             this.documentCache.set(key, {
                 value: context.result,
                 timestamp: Date.now(),
@@ -97,8 +97,8 @@ export class CachePlugin implements Plugin {
     }
     
     async onAfterDelete(context: PluginContext): Promise<void> {
-        if (this.options.enableDocumentCache && context.data?.id) {
-            const key = this.getCacheKey(context, context.data.id);
+        if (this.options.enableDocumentCache && (context.data?._id || context.data?.id)) {
+            const key = this.getCacheKey(context, context.data._id ?? context.data.id);
             this.documentCache.delete(key);
         }
         

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -101,7 +101,7 @@ export class Registry {
         const collectionSchema: CollectionSchema<InferSchema<T>> = {
             name,
             schema,
-            primaryKey: options.primaryKey || 'id',
+            primaryKey: options.primaryKey || '_id',
             version: options.version || 1,
             indexes: options.indexes || [],
             constraints: options.constraints,

--- a/src/schema-sql-generator.ts
+++ b/src/schema-sql-generator.ts
@@ -80,7 +80,7 @@ export class SchemaSQLGenerator {
                 if (fieldDef.foreignKey) {
                     const fkRef = parseForeignKeyReference(fieldDef.foreignKey);
                     if (fkRef) {
-                        // Map 'id' references to '_id' since that's the actual primary key column in BusNDB
+                        // Expect foreign keys to reference the '_id' primary key column
                         const actualColumn = fkRef.column === 'id' ? '_id' : fkRef.column;
                         columnDef += ` REFERENCES ${fkRef.table}(${actualColumn})`;
                         

--- a/src/sql-translator.ts
+++ b/src/sql-translator.ts
@@ -395,12 +395,12 @@ export class SQLTranslator {
                 const joinType = join.type === 'FULL' ? 'FULL OUTER' : join.type;
                 
                 // For joins, we need to handle field access properly for document-based storage
-                const leftFieldAccess = join.condition.left === 'id' 
-                    ? `${tableName}._id` 
+                const leftFieldAccess = join.condition.left === '_id'
+                    ? `${tableName}._id`
                     : `json_extract(${tableName}.doc, '$.${join.condition.left}')`;
-                    
-                const rightFieldAccess = join.condition.right === 'id' 
-                    ? `${join.collection}._id` 
+
+                const rightFieldAccess = join.condition.right === '_id'
+                    ? `${join.collection}._id`
                     : `json_extract(${join.collection}.doc, '$.${join.condition.right}')`;
                     
                 const operator = join.condition.operator || '=';
@@ -446,7 +446,7 @@ export class SQLTranslator {
             }
             
             // For id field, use _id column directly
-            if (fieldName === 'id') {
+            if (fieldName === '_id') {
                 return `${tablePrefix}._id`;
             }
             
@@ -471,7 +471,7 @@ export class SQLTranslator {
         }
         
         // For id field, use _id column directly
-        if (field === 'id') {
+        if (field === '_id') {
             return `${tableName}._id`;
         }
         
@@ -724,7 +724,7 @@ export class SQLTranslator {
                 // Use the specified table prefix
                 if (constrainedFields && constrainedFields[fieldName]) {
                     col = `${tablePrefix}.${fieldPathToColumnName(fieldName)}`;
-                } else if (fieldName === 'id') {
+                } else if (fieldName === '_id') {
                     col = `${tablePrefix}._id`;
                 } else {
                     col = `json_extract(${tablePrefix}.doc, '$.${fieldName}')`;

--- a/src/types/nested-paths.ts
+++ b/src/types/nested-paths.ts
@@ -118,7 +118,7 @@ export type ArrayQueryPaths<T> = {
  * Example usage types for testing autocomplete
  */
 export interface ExampleSchema {
-    id: string;
+    _id: string;
     name: string;
     age: number;
     isActive: boolean;
@@ -145,7 +145,7 @@ export interface ExampleSchema {
 
 // Test types (these should provide autocomplete)
 type TestPaths = QueryablePaths<ExampleSchema>;
-// Should include: 'id', 'name', 'age', 'metadata.category', 'metadata.priority', 
+// Should include: '_id', 'name', 'age', 'metadata.category', 'metadata.priority',
 // 'metadata.settings.theme', 'profile.bio', 'profile.social.twitter', etc.
 
 type TestOrderable = OrderablePaths<ExampleSchema>;

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createDB } from '../src/index.js';
 
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -84,7 +84,7 @@ async function runBenchmarks() {
     
     const randomIds = Array.from(
         { length: Math.min(1000, allDocs.length) },
-        () => allDocs[Math.floor(Math.random() * allDocs.length)].id
+        () => allDocs[Math.floor(Math.random() * allDocs.length)]._id
     );
 
     const pointQueryResult = benchmark('Point Queries', 1000, () => {
@@ -129,7 +129,7 @@ async function runBenchmarks() {
 
     // Benchmark: Updates
     console.log('6. Benchmarking updates...');
-    const updateIds = allDocs.slice(0, 1000).map((doc) => doc.id);
+    const updateIds = allDocs.slice(0, 1000).map((doc) => doc._id);
     const updateResult = benchmark('Updates', 1000, () => {
         updateIds.forEach((id, i) => {
             users.put(id, { score: i * 10 });
@@ -139,7 +139,7 @@ async function runBenchmarks() {
 
     // Benchmark: Deletes
     console.log('7. Benchmarking deletes...');
-    const deleteIds = allDocs.slice(1000, 2000).map((doc) => doc.id);
+    const deleteIds = allDocs.slice(1000, 2000).map((doc) => doc._id);
     const deleteResult = benchmark('Deletes', 1000, () => {
         deleteIds.forEach((id) => users.delete(id));
     });

--- a/test/connection-management.test.ts
+++ b/test/connection-management.test.ts
@@ -141,7 +141,7 @@ describe('Connection Management', () => {
             databases.push(db);
 
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 email: z.string().email(),
             });
@@ -156,12 +156,12 @@ describe('Connection Management', () => {
                 email: 'john@example.com',
             });
             
-            expect(insertedUser.id).toBeDefined();
+            expect(insertedUser._id).toBeDefined();
             expect(insertedUser.name).toBe('John Doe');
             expect(insertedUser.email).toBe('john@example.com');
             
             // Should be able to query the inserted user
-            const foundUser = await users.findById(insertedUser.id);
+            const foundUser = await users.findById(insertedUser._id);
             expect(foundUser).toEqual(insertedUser);
         });
     });

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -10,14 +10,14 @@ import {
 import type { Database } from '../src/database.js';
 
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int().optional(),
 });
 
 const postSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     title: z.string(),
     content: z.string(),
     authorId: z.string().uuid(),
@@ -91,7 +91,7 @@ describe('skibbaDB', () => {
                 age: 30,
             });
 
-            expect(user.id).toBeDefined();
+            expect(user._id).toBeDefined();
             expect(user.name).toBe('John Doe');
             expect(user.email).toBe('john@example.com');
             expect(user.age).toBe(30);
@@ -115,8 +115,8 @@ describe('skibbaDB', () => {
 
             const inserted = users.insertBulkSync(docs);
             expect(inserted).toHaveLength(2);
-            expect(inserted[0].id).toBeDefined();
-            expect(inserted[1].id).toBeDefined();
+            expect(inserted[0]._id).toBeDefined();
+            expect(inserted[1]._id).toBeDefined();
         });
 
         test('should find document by id', () => {
@@ -125,7 +125,7 @@ describe('skibbaDB', () => {
                 email: 'john@example.com',
             });
 
-            const found = users.findByIdSync(user.id);
+            const found = users.findByIdSync(user._id);
             expect(found).toEqual(user);
         });
 
@@ -141,7 +141,7 @@ describe('skibbaDB', () => {
                 age: 30,
             });
 
-            const updated = users.putSync(user.id, { age: 31 });
+            const updated = users.putSync(user._id, { age: 31 });
             expect(updated.age).toBe(31);
             expect(updated.name).toBe('John Doe');
         });
@@ -158,9 +158,9 @@ describe('skibbaDB', () => {
                 email: 'john@example.com',
             });
 
-            const deleted = users.deleteSync(user.id);
+            const deleted = users.deleteSync(user._id);
             expect(deleted).toBe(true);
-            expect(users.findByIdSync(user.id)).toBeNull();
+            expect(users.findByIdSync(user._id)).toBeNull();
         });
 
         test('should delete bulk documents', () => {
@@ -173,7 +173,7 @@ describe('skibbaDB', () => {
                 email: 'user2@example.com',
             });
 
-            const count = users.deleteBulkSync([user1.id, user2.id]);
+            const count = users.deleteBulkSync([user1._id, user2._id]);
             expect(count).toBe(2);
         });
     });

--- a/test/driver-auto-detection-bun.test.ts
+++ b/test/driver-auto-detection-bun.test.ts
@@ -126,7 +126,7 @@ describe.skipIf(isRunningInNode())(
                 try {
                     // Test basic driver operations
                     const testSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         name: z.string(),
                     });
                     const collection = db.collection('test', testSchema);
@@ -146,7 +146,7 @@ describe.skipIf(isRunningInNode())(
 
                 try {
                     const performanceSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         data: z.string(),
                     });
                     const collection = db.collection(
@@ -220,7 +220,7 @@ describe.skipIf(isRunningInNode())(
                     );
 
                     // Should reuse the same connection for shared configs
-                    expect(connection1.id).toBe(connection2.id);
+                    expect(connection1._id).toBe(connection2._id);
                 } finally {
                     await connectionManager.closeAll();
                 }
@@ -250,13 +250,13 @@ describe.skipIf(isRunningInNode())(
 
                 try {
                     const testSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                     });
                     const collection = db.collection(
                         'cleanup_test',
                         testSchema
                     );
-                    await collection.insert({ id: 'test' });
+                    await collection.insert({ _id: 'test' });
                 } finally {
                     db.close();
                 }
@@ -265,12 +265,12 @@ describe.skipIf(isRunningInNode())(
                 // Create a new database instance to test post-close behavior
                 const db2 = new Database({ path: ':memory:' });
                 const testSchema2 = z.object({
-                    id: z.string(),
+                    _id: z.string(),
                 });
                 const collection = db2.collection('cleanup_test', testSchema2);
 
                 try {
-                    await collection.insert({ id: 'test2' });
+                    await collection.insert({ _id: 'test2' });
                     // This should work since it's a new database instance
                     const results = await collection.toArray();
                     expect(results).toHaveLength(1);
@@ -308,7 +308,7 @@ describe.skipIf(isRunningInNode())(
 
                 try {
                     const concurrentSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         value: z.number(),
                     });
                     const collection = db.collection(
@@ -345,7 +345,7 @@ describe.skipIf(isRunningInNode())(
                 try {
                     // Test that we can use Bun's fast SQLite implementation
                     const bunSqliteSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         timestamp: z.number(),
                     });
                     const collection = db.collection(

--- a/test/driver-auto-detection-node.test.ts
+++ b/test/driver-auto-detection-node.test.ts
@@ -144,18 +144,18 @@ describe.skipIf(isRunningInBun())(
                 try {
                     // Test basic driver operations
                     const testSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         name: z.string(),
                     });
                     const collection = db.collection('test', testSchema);
 
                     // Correct: do not pass id to insert
                     const inserted = await collection.insert({ name: 'test' });
-                    expect(inserted.id).toBeDefined();
+                    expect(inserted._id).toBeDefined();
                     expect(inserted.name).toBe('test');
 
                     // Use findById and toArray async
-                    const found = await collection.findById(inserted.id);
+                    const found = await collection.findById(inserted._id);
                     expect(found).toEqual(inserted);
 
                     const results = await collection.toArray();
@@ -163,16 +163,16 @@ describe.skipIf(isRunningInBun())(
                     expect(results[0].name).toBe('test');
 
                     // Update using put
-                    const updated = await collection.put(inserted.id, {
+                    const updated = await collection.put(inserted._id, {
                         name: 'updated',
                     });
                     expect(updated.name).toBe('updated');
-                    expect(updated.id).toBe(inserted.id);
+                    expect(updated._id).toBe(inserted._id);
 
                     // Delete using delete
-                    const deleted = await collection.delete(inserted.id);
+                    const deleted = await collection.delete(inserted._id);
                     expect(deleted).toBe(true);
-                    const afterDelete = await collection.findById(inserted.id);
+                    const afterDelete = await collection.findById(inserted._id);
                     expect(afterDelete).toBeNull();
                 } finally {
                     db.close();
@@ -185,7 +185,7 @@ describe.skipIf(isRunningInBun())(
 
                 try {
                     const performanceSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         data: z.string(),
                     });
                     const collection = db.collection(
@@ -261,7 +261,7 @@ describe.skipIf(isRunningInBun())(
                     );
 
                     // Should reuse the same connection for shared configs
-                    expect(connection1.id).toBe(connection2.id);
+                    expect(connection1._id).toBe(connection2._id);
                 } finally {
                     await connectionManager.closeAll();
                 }
@@ -305,7 +305,7 @@ describe.skipIf(isRunningInBun())(
 
                 try {
                     const testSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                     });
                     const collection = db.collection(
                         'node_test_cleanup',
@@ -319,7 +319,7 @@ describe.skipIf(isRunningInBun())(
                 // After closing, subsequent operations should fail gracefully
                 const db2 = new Database({ path: ':memory:' });
                 const testSchema2 = z.object({
-                    id: z.string(),
+                    _id: z.string(),
                 });
                 const collection2 = db2.collection(
                     'node_test_cleanup2',
@@ -364,7 +364,7 @@ describe.skipIf(isRunningInBun())(
 
                 try {
                     const concurrentSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         value: z.number(),
                     });
                     const collection = db.collection(
@@ -406,7 +406,7 @@ describe.skipIf(isRunningInBun())(
                 try {
                     // Test that we can use better-sqlite3
                     const nodeSqliteSchema = z.object({
-                        id: z.string(),
+                        _id: z.string(),
                         timestamp: z.number(),
                     });
                     const collection = db.collection(
@@ -431,14 +431,14 @@ describe.skipIf(isRunningInBun())(
 
                 // Simulate process exit scenarios
                 const cleanupSchema = z.object({
-                    id: z.string(),
+                    _id: z.string(),
                 });
                 const collection = db.collection(
                     'cleanup_test_node',
                     cleanupSchema
                 );
 
-                await collection.insert({ id: 'test' });
+                await collection.insert({ _id: 'test' });
 
                 // Clean shutdown
                 db.close();

--- a/test/enhanced-plugin-system.test.ts
+++ b/test/enhanced-plugin-system.test.ts
@@ -6,7 +6,7 @@ import type { Database } from '../src/database';
 // Import our hello world plugin examples will be done dynamically in tests
 
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
 });
@@ -168,10 +168,10 @@ describe('Enhanced Plugin System', () => {
         await users.toArray();
 
         // Test update
-        await users.put(user.id, { name: 'Updated User' });
+        await users.put(user._id, { name: 'Updated User' });
 
         // Test delete
-        await users.delete(user.id);
+        await users.delete(user._id);
 
         // Verify all hooks were called
         expect(

--- a/test/enhanced-query-engine.test.ts
+++ b/test/enhanced-query-engine.test.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Test schemas
 const UserSchema = z.object({
-    id: z.string(),
+    _id: z.string(),
     name: z.string(),
     email: z.string(),
     age: z.number(),
@@ -29,7 +29,7 @@ const UserSchema = z.object({
 });
 
 const OrderSchema = z.object({
-    id: z.string(),
+    _id: z.string(),
     userId: z.string(),
     total: z.number(),
     items: z.array(
@@ -44,7 +44,7 @@ const OrderSchema = z.object({
 });
 
 const ProductSchema = z.object({
-    id: z.string(),
+    _id: z.string(),
     name: z.string(),
     price: z.number(),
     category: z.string(),
@@ -70,16 +70,16 @@ describe('Enhanced Query Engine', () => {
         db = new Database({ memory: true });
 
         // Create collections
-        users = db.collection('users', UserSchema, { primaryKey: 'id' });
-        orders = db.collection('orders', OrderSchema, { primaryKey: 'id' });
+        users = db.collection('users', UserSchema, { primaryKey: '_id' });
+        orders = db.collection('orders', OrderSchema, { primaryKey: '_id' });
         products = db.collection('products', ProductSchema, {
-            primaryKey: 'id',
+            primaryKey: '_id',
         });
 
         // Sample data
         const sampleUsers = [
             {
-                id: '1',
+                _id: '1',
                 name: 'Alice Smith',
                 email: 'alice@example.com',
                 age: 28,
@@ -91,7 +91,7 @@ describe('Enhanced Query Engine', () => {
                 metadata: { category: 'premium', score: 95 },
             },
             {
-                id: '2',
+                _id: '2',
                 name: 'Bob Johnson',
                 email: 'bob@example.com',
                 age: 35,
@@ -103,7 +103,7 @@ describe('Enhanced Query Engine', () => {
                 metadata: { category: 'standard', score: 82 },
             },
             {
-                id: '3',
+                _id: '3',
                 name: 'Carol Davis',
                 email: 'carol@example.com',
                 age: 24,
@@ -117,7 +117,7 @@ describe('Enhanced Query Engine', () => {
 
         const sampleOrders = [
             {
-                id: 'order1',
+                _id: 'order1',
                 userId: '1',
                 total: 150.5,
                 items: [
@@ -128,7 +128,7 @@ describe('Enhanced Query Engine', () => {
                 createdAt: new Date('2024-01-15'),
             },
             {
-                id: 'order2',
+                _id: 'order2',
                 userId: '1',
                 total: 75.25,
                 items: [{ name: 'Keyboard', price: 75.25, quantity: 1 }],
@@ -136,7 +136,7 @@ describe('Enhanced Query Engine', () => {
                 createdAt: new Date('2024-01-20'),
             },
             {
-                id: 'order3',
+                _id: 'order3',
                 userId: '2',
                 total: 200.0,
                 items: [{ name: 'Monitor', price: 200, quantity: 1 }],
@@ -147,7 +147,7 @@ describe('Enhanced Query Engine', () => {
 
         const sampleProducts = [
             {
-                id: 'prod1',
+                _id: 'prod1',
                 name: 'Laptop',
                 price: 1000,
                 category: 'electronics',
@@ -158,7 +158,7 @@ describe('Enhanced Query Engine', () => {
                 ],
             },
             {
-                id: 'prod2',
+                _id: 'prod2',
                 name: 'Mouse',
                 price: 25,
                 category: 'electronics',
@@ -166,7 +166,7 @@ describe('Enhanced Query Engine', () => {
                 reviews: [{ rating: 4, comment: 'Works well', userId: '1' }],
             },
             {
-                id: 'prod3',
+                _id: 'prod3',
                 name: 'Desk',
                 price: 300,
                 category: 'furniture',
@@ -285,7 +285,7 @@ describe('Enhanced Query Engine', () => {
             const result = await users
                 .query()
                 .select('name', 'email')
-                .join('orders', 'id', 'userId')
+                .join('orders', '_id', 'userId')
                 .where('total')
                 .gt(100)
                 .exec();
@@ -300,7 +300,7 @@ describe('Enhanced Query Engine', () => {
             const result = await users
                 .query()
                 .select('name')
-                .leftJoin('orders', 'id', 'userId')
+                .leftJoin('orders', '_id', 'userId')
                 .exec();
 
             // Should include all users, even those without orders
@@ -310,7 +310,7 @@ describe('Enhanced Query Engine', () => {
         it('should join with custom operators', async () => {
             const result = await orders
                 .query()
-                .select('id', 'total')
+                .select('_id', 'total')
                 .join('products', 'total', 'price', '>')
                 .exec();
 
@@ -330,7 +330,7 @@ describe('Enhanced Query Engine', () => {
 
             const result = await users
                 .query()
-                .where('id')
+                .where('_id')
                 .existsSubquery(subquery, 'orders')
                 .exec();
 
@@ -343,7 +343,7 @@ describe('Enhanced Query Engine', () => {
 
             const result = await users
                 .query()
-                .where('id')
+                .where('_id')
                 .notExistsSubquery(subquery, 'orders')
                 .exec();
 
@@ -360,7 +360,7 @@ describe('Enhanced Query Engine', () => {
 
             const result = await users
                 .query()
-                .where('id')
+                .where('_id')
                 .inSubquery(subquery, 'orders')
                 .exec();
 
@@ -377,7 +377,7 @@ describe('Enhanced Query Engine', () => {
 
             const result = await users
                 .query()
-                .where('id')
+                .where('_id')
                 .notInSubquery(subquery, 'orders')
                 .exec();
 
@@ -467,7 +467,7 @@ describe('Enhanced Query Engine', () => {
             // Find premium users and their order statistics
             const premiumUserSubquery = users
                 .query()
-                .select('id')
+                .select('_id')
                 .where('metadata.category')
                 .eq('premium');
 

--- a/test/index-benchmark.test.ts
+++ b/test/index-benchmark.test.ts
@@ -4,7 +4,7 @@ import { index } from '../src/schema-constraints.js';
 
 // Define a comprehensive schema with both shallow and deep fields
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,7 +9,7 @@ import {
 import { unique, foreignKey, check, index } from '../src/schema-constraints.js';
 
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int().optional(),
@@ -19,7 +19,7 @@ const userSchema = z.object({
 });
 
 const postSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     title: z.string(),
     content: z.string(),
     authorId: z.string().uuid(),
@@ -46,7 +46,7 @@ describe('Integration: skibbaDB End-to-End', () => {
         posts = db.collection('posts', postSchema, {
             constraints: {
                 constraints: {
-                    authorId: foreignKey('users', 'id'),
+                    authorId: foreignKey('users', '_id'),
                 },
                 indexes: {
                     title: index('title'),
@@ -60,8 +60,8 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Alice',
             email: 'alice@example.com',
         });
-        expect(user.id).toBeDefined();
-        const found = users.findByIdSync(user.id);
+        expect(user._id).toBeDefined();
+        const found = users.findByIdSync(user._id);
         expect(found).toEqual(user);
     });
 
@@ -72,8 +72,8 @@ describe('Integration: skibbaDB End-to-End', () => {
         ];
         const inserted = users.insertBulkSync(docs);
         expect(inserted).toHaveLength(2);
-        expect(inserted[0].id).toBeDefined();
-        expect(inserted[1].id).toBeDefined();
+        expect(inserted[0]._id).toBeDefined();
+        expect(inserted[1]._id).toBeDefined();
     });
 
     test('unique constraint violation', () => {
@@ -94,7 +94,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Frank',
             email: 'frank@example.com',
         });
-        const updated = users.putSync(user.id, { name: 'Franklin' });
+        const updated = users.putSync(user._id, { name: 'Franklin' });
         expect(updated.name).toBe('Franklin');
         expect(updated.email).toBe('frank@example.com');
     });
@@ -110,8 +110,8 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Helen',
             email: 'helen@example.com',
         });
-        expect(users.deleteSync(user.id)).toBe(true);
-        expect(users.findByIdSync(user.id)).toBeNull();
+        expect(users.deleteSync(user._id)).toBe(true);
+        expect(users.findByIdSync(user._id)).toBeNull();
     });
 
     test('delete bulk users', () => {
@@ -120,7 +120,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Jack',
             email: 'jack@example.com',
         });
-        expect(users.deleteBulkSync([u1.id, u2.id])).toBe(2);
+        expect(users.deleteBulkSync([u1._id, u2._id])).toBe(2);
     });
 
     test('foreign key constraint', () => {
@@ -131,9 +131,9 @@ describe('Integration: skibbaDB End-to-End', () => {
         const post = posts.insertSync({
             title: 'Hello',
             content: 'World',
-            authorId: user.id,
+            authorId: user._id,
         });
-        expect(post.authorId).toBe(user.id);
+        expect(post.authorId).toBe(user._id);
         expect(() =>
             posts.insertSync({
                 title: 'Bad',
@@ -263,16 +263,16 @@ describe('Integration: skibbaDB End-to-End', () => {
     test('putBulk/upsert/upsertBulk', () => {
         const u = users.insertSync({ name: 'Bulk', email: 'bulk@example.com' });
         const updated = users.putBulkSync([
-            { id: u.id, doc: { name: 'Bulk2' } },
+            { _id: u._id, doc: { name: 'Bulk2' } },
         ]);
         expect(updated[0].name).toBe('Bulk2');
-        const up = users.upsertSync(u.id, {
+        const up = users.upsertSync(u._id, {
             name: 'Bulk3',
             email: 'bulk3@example.com',
         });
         expect(up.name).toBe('Bulk3');
         const upBulk = users.upsertBulkSync([
-            { id: u.id, doc: { name: 'Bulk4', email: 'bulk4@example.com' } },
+            { _id: u._id, doc: { name: 'Bulk4', email: 'bulk4@example.com' } },
         ]);
         expect(upBulk[0].name).toBe('Bulk4');
     });
@@ -301,7 +301,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             email: 'edge2@example.com',
         });
         expect(() =>
-            users.putSync(u2.id, { email: 'edge1@example.com' })
+            users.putSync(u2._id, { email: 'edge1@example.com' })
         ).toThrow(UniqueConstraintError);
     });
 
@@ -311,7 +311,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             email: 'edge3@example.com',
         });
         expect(() =>
-            users.upsertSync(u1.id, {
+            users.upsertSync(u1._id, {
                 name: 'Edge3',
                 email: 'edge3@example.com',
             })
@@ -321,7 +321,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             email: 'edge4@example.com',
         });
         expect(() =>
-            users.upsertSync(u2.id, {
+            users.upsertSync(u2._id, {
                 name: 'Edge4',
                 email: 'edge3@example.com',
             })
@@ -337,7 +337,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Edge5',
             email: 'edge5@example.com',
         });
-        expect(users.deleteBulkSync([u.id, 'bad-id'])).toBe(2);
+        expect(users.deleteBulkSync([u._id, 'bad-id'])).toBe(2);
     });
 
     test('edge: upsertBulk with new and existing', () => {
@@ -348,9 +348,9 @@ describe('Integration: skibbaDB End-to-End', () => {
         // Generate a valid uuid for the new id
         const newId = crypto.randomUUID();
         const res = users.upsertBulkSync([
-            { id: u.id, doc: { name: 'Edge6-up', email: 'edge6@example.com' } },
+            { _id: u._id, doc: { name: 'Edge6-up', email: 'edge6@example.com' } },
             {
-                id: newId,
+                _id: newId,
                 doc: { name: 'Edge7', email: 'edge7@example.com' },
             },
         ]);
@@ -366,7 +366,7 @@ describe('Integration: skibbaDB End-to-End', () => {
             }));
             const inserted = users.insertBulkSync(docs);
             expect(inserted.length).toBe(5);
-            const ids = inserted.map((u) => u.id);
+            const ids = inserted.map((u) => u._id);
             expect(users.deleteBulkSync(ids)).toBe(5);
         });
     }
@@ -428,7 +428,7 @@ describe('Integration: skibbaDB End-to-End', () => {
         const u = users.insertSync({ name: 'Dup', email: 'dup@example.com' });
         expect(() =>
             users.insertSync({
-                id: u.id,
+                _id: u._id,
                 name: 'Dup2',
                 email: 'dup2@example.com',
             } as any)
@@ -528,7 +528,7 @@ describe('Integration: skibbaDB End-to-End', () => {
     test('insert with invalid uuid', () => {
         expect(() =>
             users.insertSync({
-                id: 'not-a-uuid',
+                _id: 'not-a-uuid',
                 name: 'Bad',
                 email: 'bad@example.com',
             } as any)
@@ -541,6 +541,6 @@ describe('Integration: skibbaDB End-to-End', () => {
             name: 'Good',
             email: 'good@example.com',
         });
-        expect(user.id).toBe(id);
+        expect(user._id).toBe(id);
     });
 });

--- a/test/migrations.test.ts
+++ b/test/migrations.test.ts
@@ -12,7 +12,7 @@ describe('Schema Migrations', () => {
 
     it('should add version field to collection schema', () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string(),
         });
@@ -23,7 +23,7 @@ describe('Schema Migrations', () => {
 
     it('should handle collections without explicit version (defaults to 1)', () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
@@ -68,12 +68,12 @@ describe('Schema Migrations', () => {
         const migrator = new Migrator(driver);
         
         const oldSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
         
         const newSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
             age: z.number().optional(),
@@ -92,13 +92,13 @@ describe('Schema Migrations', () => {
         const migrator = new Migrator(driver);
         
         const oldSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string(),
         });
         
         const newSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
         
@@ -113,12 +113,12 @@ describe('Schema Migrations', () => {
         const migrator = new Migrator(driver);
         
         const oldSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             age: z.string(),
         });
         
         const newSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             age: z.number(),
         });
         
@@ -130,7 +130,7 @@ describe('Schema Migrations', () => {
 
     it('should run migration for new collection', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
         });
@@ -140,13 +140,13 @@ describe('Schema Migrations', () => {
         
         // Insert a test document to ensure the collection works
         const user = await users.insert({ name: 'John', email: 'john@example.com' });
-        expect(user.id).toBeDefined();
+        expect(user._id).toBeDefined();
         expect(user.name).toBe('John');
     });
 
     it('should get migration status', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
@@ -167,7 +167,7 @@ describe('Schema Migrations', () => {
         
         try {
             const UserSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
             });
 
@@ -189,7 +189,7 @@ describe('Schema Migrations', () => {
         const migrator = new Migrator(driver);
         
         const schema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             age: z.number(),
             isActive: z.boolean(),

--- a/test/or-queries.test.ts
+++ b/test/or-queries.test.ts
@@ -4,7 +4,7 @@ import { createDB } from '../src/index.js';
 import type { Database } from '../src/database.js';
 
 const testSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -343,8 +343,8 @@ describe('OR Query Operations', () => {
             expect(page2.length).toBeGreaterThan(0);
 
             // Ensure no duplicates between pages
-            const page1Ids = page1.map((r) => r.id);
-            const page2Ids = page2.map((r) => r.id);
+            const page1Ids = page1.map((r) => r._id);
+            const page2Ids = page2.map((r) => r._id);
             const overlap = page1Ids.filter((id) => page2Ids.includes(id));
             expect(overlap).toHaveLength(0);
         });

--- a/test/plugin-system.test.ts
+++ b/test/plugin-system.test.ts
@@ -17,18 +17,18 @@ describe('PluginManager', () => {
                 name: 'testCollection',
                 fields: [
                     {
-                        name: 'id',
+                        name: '_id',
                         type: 'string',
                         unique: true,
                         primaryKey: true,
                     },
                 ],
-                primaryKey: 'id',
+                primaryKey: '_id',
                 indexes: [],
                 constraints: [],
             } as unknown as CollectionSchema, // Using unknown to bypass strict CollectionSchema typing for tests
             operation: 'testOperation',
-            data: { id: 1, name: 'testData' },
+            data: { _id: 1, name: 'testData' },
             result: undefined,
             error: undefined,
         };

--- a/test/query-builder-bugs.test.ts
+++ b/test/query-builder-bugs.test.ts
@@ -5,7 +5,7 @@ import { QueryBuilder } from '../src/query-builder.js';
 import type { Database } from '../src/database.js';
 
 const testSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),

--- a/test/query-builder.test.ts
+++ b/test/query-builder.test.ts
@@ -4,7 +4,7 @@ import { createDB } from '../src/index.js';
 import type { Database } from '../src/database.js';
 
 const testSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -386,7 +386,7 @@ describe('Query Builder - Feature Complete Tests', () => {
             expect(page3).toHaveLength(1);
 
             // Ensure no overlap
-            const allIds = [...page1, ...page2, ...page3].map((r) => r.id);
+            const allIds = [...page1, ...page2, ...page3].map((r) => r._id);
             const uniqueIds = new Set(allIds);
             expect(uniqueIds.size).toBe(allIds.length);
         });
@@ -513,7 +513,7 @@ describe('Query Builder - Feature Complete Tests', () => {
             const clonedResults = cloned.toArraySync();
 
             expect(originalResults).toHaveLength(clonedResults.length);
-            expect(originalResults[0].id).toBe(clonedResults[0].id);
+            expect(originalResults[0]._id).toBe(clonedResults[0]._id);
 
             // Modifying clone shouldn't affect original
             cloned.where('isActive').eq(true);

--- a/test/relationships.test.ts
+++ b/test/relationships.test.ts
@@ -10,7 +10,7 @@ import type { Database } from '../src/database.js';
 
 // Schemas for relationship testing
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int().optional(),
@@ -18,7 +18,7 @@ const userSchema = z.object({
 });
 
 const postSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     title: z.string(),
     content: z.string(),
     authorId: z.string().uuid(),
@@ -27,7 +27,7 @@ const postSchema = z.object({
 });
 
 const commentSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     content: z.string(),
     postId: z.string().uuid(),
     authorId: z.string().uuid(),
@@ -35,31 +35,31 @@ const commentSchema = z.object({
 });
 
 const categorySchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     description: z.string().optional(),
 });
 
 const postCategorySchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     postId: z.string().uuid(),
     categoryId: z.string().uuid(),
 });
 
 const tagSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     color: z.string().optional(),
 });
 
 const postTagSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     postId: z.string().uuid(),
     tagId: z.string().uuid(),
 });
 
 const profileSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     userId: z.string().uuid(),
     bio: z.string().optional(),
     website: z.string().optional(),
@@ -118,40 +118,40 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'Alice First Post',
                 content: 'This is Alice first post',
-                authorId: user1.id,
+                authorId: user1._id,
                 published: true,
             });
 
             const post2 = posts.insertSync({
                 title: 'Alice Second Post',
                 content: 'This is Alice second post',
-                authorId: user1.id,
+                authorId: user1._id,
                 published: false,
             });
 
             const post3 = posts.insertSync({
                 title: 'Bob First Post',
                 content: 'This is Bob first post',
-                authorId: user2.id,
+                authorId: user2._id,
                 published: true,
             });
 
             // Test finding posts by author using direct filtering
             const alicePosts = posts
                 .where('authorId')
-                .eq(user1.id)
+                .eq(user1._id)
                 .toArraySync();
             expect(alicePosts).toHaveLength(2);
-            expect(alicePosts.every((p) => p.authorId === user1.id)).toBe(true);
+            expect(alicePosts.every((p) => p.authorId === user1._id)).toBe(true);
 
-            const bobPosts = posts.where('authorId').eq(user2.id).toArraySync();
+            const bobPosts = posts.where('authorId').eq(user2._id).toArraySync();
             expect(bobPosts).toHaveLength(1);
-            expect(bobPosts[0].authorId).toBe(user2.id);
+            expect(bobPosts[0].authorId).toBe(user2._id);
 
             // Test filtering published posts by author
             const alicePublishedPosts = posts
                 .where('authorId')
-                .eq(user1.id)
+                .eq(user1._id)
                 .and()
                 .where('published')
                 .eq(true)
@@ -170,46 +170,46 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'Test Post',
                 content: 'Test content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Create comments for the post
             const comment1 = comments.insertSync({
                 content: 'Great post!',
-                postId: post.id,
-                authorId: user.id,
+                postId: post._id,
+                authorId: user._id,
             });
 
             const comment2 = comments.insertSync({
                 content: 'Very informative',
-                postId: post.id,
-                authorId: user.id,
+                postId: post._id,
+                authorId: user._id,
             });
 
             // Another post and comment
             const anotherPost = posts.insertSync({
                 title: 'Another Post',
                 content: 'Another content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const comment3 = comments.insertSync({
                 content: 'Comment on another post',
-                postId: anotherPost.id,
-                authorId: user.id,
+                postId: anotherPost._id,
+                authorId: user._id,
             });
 
             // Test finding comments by post
             const postComments = comments
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .toArraySync();
             expect(postComments).toHaveLength(2);
-            expect(postComments.every((c) => c.postId === post.id)).toBe(true);
+            expect(postComments.every((c) => c.postId === post._id)).toBe(true);
 
             const anotherPostComments = comments
                 .where('postId')
-                .eq(anotherPost.id)
+                .eq(anotherPost._id)
                 .toArraySync();
             expect(anotherPostComments).toHaveLength(1);
             expect(anotherPostComments[0].content).toBe(
@@ -227,48 +227,48 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'Post 1',
                 content: 'Content 1',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const post2 = posts.insertSync({
                 title: 'Post 2',
                 content: 'Content 2',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Create comments
             comments.insertSync({
                 content: 'Comment 1',
-                postId: post1.id,
-                authorId: user.id,
+                postId: post1._id,
+                authorId: user._id,
             });
 
             comments.insertSync({
                 content: 'Comment 2',
-                postId: post2.id,
-                authorId: user.id,
+                postId: post2._id,
+                authorId: user._id,
             });
 
             // Verify initial state
-            expect(posts.where('authorId').eq(user.id).countSync()).toBe(2);
-            expect(comments.where('authorId').eq(user.id).countSync()).toBe(2);
+            expect(posts.where('authorId').eq(user._id).countSync()).toBe(2);
+            expect(comments.where('authorId').eq(user._id).countSync()).toBe(2);
 
             // Simulate cascading delete: delete comments first, then posts, then user
             const userComments = comments
                 .where('authorId')
-                .eq(user.id)
+                .eq(user._id)
                 .toArraySync();
-            userComments.forEach((comment) => comments.deleteSync(comment.id));
+            userComments.forEach((comment) => comments.deleteSync(comment._id));
 
-            const userPosts = posts.where('authorId').eq(user.id).toArraySync();
-            userPosts.forEach((post) => posts.deleteSync(post.id));
+            const userPosts = posts.where('authorId').eq(user._id).toArraySync();
+            userPosts.forEach((post) => posts.deleteSync(post._id));
 
-            users.deleteSync(user.id);
+            users.deleteSync(user._id);
 
             // Verify deletion
-            expect(users.findByIdSync(user.id)).toBeNull();
-            expect(posts.where('authorId').eq(user.id).countSync()).toBe(0);
-            expect(comments.where('authorId').eq(user.id).countSync()).toBe(0);
+            expect(users.findByIdSync(user._id)).toBeNull();
+            expect(posts.where('authorId').eq(user._id).countSync()).toBe(0);
+            expect(comments.where('authorId').eq(user._id).countSync()).toBe(0);
         });
     });
 
@@ -283,7 +283,7 @@ describe('Relationship Testing', () => {
 
             // Create profile for user
             const profile = profiles.insertSync({
-                userId: user.id,
+                userId: user._id,
                 bio: 'Software developer',
                 website: 'https://example.com',
                 avatar: 'avatar.jpg',
@@ -292,24 +292,24 @@ describe('Relationship Testing', () => {
             // Test finding profile by user
             const userProfile = profiles
                 .where('userId')
-                .eq(user.id)
+                .eq(user._id)
                 .firstSync();
             expect(userProfile).not.toBeNull();
-            expect(userProfile?.userId).toBe(user.id);
+            expect(userProfile?.userId).toBe(user._id);
             expect(userProfile?.bio).toBe('Software developer');
 
             // Test uniqueness constraint simulation
             // In a real application, you would enforce this at the schema level
             const existingProfile = profiles
                 .where('userId')
-                .eq(user.id)
+                .eq(user._id)
                 .firstSync();
             expect(existingProfile).not.toBeNull();
 
             // Attempting to create another profile should be prevented by application logic
             const duplicateProfileCheck = profiles
                 .where('userId')
-                .eq(user.id)
+                .eq(user._id)
                 .countSync();
             expect(duplicateProfileCheck).toBe(1);
         });
@@ -321,12 +321,12 @@ describe('Relationship Testing', () => {
             });
 
             const profile = profiles.insertSync({
-                userId: user.id,
+                userId: user._id,
                 bio: 'Original bio',
             });
 
             // Update profile
-            const updatedProfile = profiles.putSync(profile.id, {
+            const updatedProfile = profiles.putSync(profile._id, {
                 bio: 'Updated bio',
                 website: 'https://updated.com',
             });
@@ -335,15 +335,15 @@ describe('Relationship Testing', () => {
             expect(updatedProfile.website).toBe('https://updated.com');
 
             // Delete profile
-            profiles.deleteSync(profile.id);
+            profiles.deleteSync(profile._id);
             const deletedProfile = profiles
                 .where('userId')
-                .eq(user.id)
+                .eq(user._id)
                 .firstSync();
             expect(deletedProfile).toBeNull();
 
             // User should still exist
-            const existingUser = users.findByIdSync(user.id);
+            const existingUser = users.findByIdSync(user._id);
             expect(existingUser).not.toBeNull();
         });
     });
@@ -375,72 +375,72 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'JavaScript Basics',
                 content: 'Learn JavaScript fundamentals',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const post2 = posts.insertSync({
                 title: 'React Tutorial',
                 content: 'Build apps with React',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Create many-to-many relationships
             // Post 1 belongs to Tech and Programming
             postCategories.insertSync({
-                postId: post1.id,
-                categoryId: techCategory.id,
+                postId: post1._id,
+                categoryId: techCategory._id,
             });
 
             postCategories.insertSync({
-                postId: post1.id,
-                categoryId: programmingCategory.id,
+                postId: post1._id,
+                categoryId: programmingCategory._id,
             });
 
             // Post 2 belongs to all three categories
             postCategories.insertSync({
-                postId: post2.id,
-                categoryId: techCategory.id,
+                postId: post2._id,
+                categoryId: techCategory._id,
             });
 
             postCategories.insertSync({
-                postId: post2.id,
-                categoryId: programmingCategory.id,
+                postId: post2._id,
+                categoryId: programmingCategory._id,
             });
 
             postCategories.insertSync({
-                postId: post2.id,
-                categoryId: tutorialCategory.id,
+                postId: post2._id,
+                categoryId: tutorialCategory._id,
             });
 
             // Test finding categories for a post
             const post1CategoryIds = postCategories
                 .where('postId')
-                .eq(post1.id)
+                .eq(post1._id)
                 .toArraySync()
                 .map((pc) => pc.categoryId);
 
             expect(post1CategoryIds).toHaveLength(2);
-            expect(post1CategoryIds).toContain(techCategory.id);
-            expect(post1CategoryIds).toContain(programmingCategory.id);
+            expect(post1CategoryIds).toContain(techCategory._id);
+            expect(post1CategoryIds).toContain(programmingCategory._id);
 
             // Test finding posts for a category
             const techPostIds = postCategories
                 .where('categoryId')
-                .eq(techCategory.id)
+                .eq(techCategory._id)
                 .toArraySync()
                 .map((pc) => pc.postId);
 
             expect(techPostIds).toHaveLength(2);
-            expect(techPostIds).toContain(post1.id);
-            expect(techPostIds).toContain(post2.id);
+            expect(techPostIds).toContain(post1._id);
+            expect(techPostIds).toContain(post2._id);
 
             // Test finding posts with specific category using subquery
             const programmingPosts = posts
-                .where('id')
+                .where('_id')
                 .inSubquery(
                     postCategories
                         .where('categoryId')
-                        .eq(programmingCategory.id)
+                        .eq(programmingCategory._id)
                         .select('postId'),
                     'post_categories'
                 )
@@ -475,42 +475,42 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'React with JavaScript',
                 content: 'Advanced React patterns',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Tag the post
-            postTags.insertSync({ postId: post.id, tagId: jsTag.id });
-            postTags.insertSync({ postId: post.id, tagId: reactTag.id });
-            postTags.insertSync({ postId: post.id, tagId: webdevTag.id });
+            postTags.insertSync({ postId: post._id, tagId: jsTag._id });
+            postTags.insertSync({ postId: post._id, tagId: reactTag._id });
+            postTags.insertSync({ postId: post._id, tagId: webdevTag._id });
 
             // Test finding tags for post
             const postTagIds = postTags
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .toArraySync()
                 .map((pt) => pt.tagId);
 
             expect(postTagIds).toHaveLength(3);
-            expect(postTagIds).toContain(jsTag.id);
-            expect(postTagIds).toContain(reactTag.id);
-            expect(postTagIds).toContain(webdevTag.id);
+            expect(postTagIds).toContain(jsTag._id);
+            expect(postTagIds).toContain(reactTag._id);
+            expect(postTagIds).toContain(webdevTag._id);
 
             // Test removing a tag from post
             const jsPostTag = postTags
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .and()
                 .where('tagId')
-                .eq(jsTag.id)
+                .eq(jsTag._id)
                 .firstSync();
 
             if (jsPostTag) {
-                postTags.deleteSync(jsPostTag.id);
+                postTags.deleteSync(jsPostTag._id);
             }
 
             const remainingTags = postTags
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .countSync();
             expect(remainingTags).toBe(2);
         });
@@ -529,49 +529,49 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'Frontend Development',
                 content: 'Frontend guide',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const post2 = posts.insertSync({
                 title: 'Backend APIs',
                 content: 'API development',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const post3 = posts.insertSync({
                 title: 'Full Stack App',
                 content: 'End-to-end development',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Tag posts
-            postTags.insertSync({ postId: post1.id, tagId: frontendTag.id });
-            postTags.insertSync({ postId: post2.id, tagId: backendTag.id });
-            postTags.insertSync({ postId: post3.id, tagId: frontendTag.id });
-            postTags.insertSync({ postId: post3.id, tagId: backendTag.id });
-            postTags.insertSync({ postId: post3.id, tagId: fullstackTag.id });
+            postTags.insertSync({ postId: post1._id, tagId: frontendTag._id });
+            postTags.insertSync({ postId: post2._id, tagId: backendTag._id });
+            postTags.insertSync({ postId: post3._id, tagId: frontendTag._id });
+            postTags.insertSync({ postId: post3._id, tagId: backendTag._id });
+            postTags.insertSync({ postId: post3._id, tagId: fullstackTag._id });
 
             // Find posts tagged with 'Frontend'
             const frontendPostIds = postTags
                 .where('tagId')
-                .eq(frontendTag.id)
+                .eq(frontendTag._id)
                 .toArraySync()
                 .map((pt) => pt.postId);
 
             expect(frontendPostIds).toHaveLength(2);
-            expect(frontendPostIds).toContain(post1.id);
-            expect(frontendPostIds).toContain(post3.id);
+            expect(frontendPostIds).toContain(post1._id);
+            expect(frontendPostIds).toContain(post3._id);
 
             // Find posts tagged with both 'Frontend' and 'Backend'
             const frontendPosts = postTags
                 .where('tagId')
-                .eq(frontendTag.id)
+                .eq(frontendTag._id)
                 .toArraySync()
                 .map((pt) => pt.postId);
 
             const backendPosts = postTags
                 .where('tagId')
-                .eq(backendTag.id)
+                .eq(backendTag._id)
                 .toArraySync()
                 .map((pt) => pt.postId);
 
@@ -579,7 +579,7 @@ describe('Relationship Testing', () => {
                 backendPosts.includes(id)
             );
             expect(bothTagsPosts).toHaveLength(1);
-            expect(bothTagsPosts[0]).toBe(post3.id);
+            expect(bothTagsPosts[0]).toBe(post3._id);
         });
     });
 
@@ -594,23 +594,23 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'Post',
                 content: 'Content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Delete user but leave post (creating orphan)
-            users.deleteSync(user.id);
+            users.deleteSync(user._id);
 
             // Post still exists but references non-existent user
-            const orphanPost = posts.findByIdSync(post.id);
+            const orphanPost = posts.findByIdSync(post._id);
             expect(orphanPost).not.toBeNull();
-            expect(orphanPost?.authorId).toBe(user.id);
+            expect(orphanPost?.authorId).toBe(user._id);
 
             // Verify user doesn't exist
-            const deletedUser = users.findByIdSync(user.id);
+            const deletedUser = users.findByIdSync(user._id);
             expect(deletedUser).toBeNull();
 
             // Clean up orphaned post
-            posts.deleteSync(post.id);
+            posts.deleteSync(post._id);
         });
 
         test('should handle circular references in relationships', () => {
@@ -629,35 +629,35 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'Original Post',
                 content: 'Post content',
-                authorId: user1.id,
+                authorId: user1._id,
             });
 
             const comment = comments.insertSync({
                 content: 'Comment by User 2',
-                postId: post.id,
-                authorId: user2.id,
+                postId: post._id,
+                authorId: user2._id,
             });
 
             const reply = comments.insertSync({
                 content: 'Reply by User 1',
-                postId: post.id,
-                authorId: user1.id,
+                postId: post._id,
+                authorId: user1._id,
             });
 
             // Test finding all interactions
             const postComments = comments
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .toArraySync();
             expect(postComments).toHaveLength(2);
 
             const user1Comments = comments
                 .where('authorId')
-                .eq(user1.id)
+                .eq(user1._id)
                 .toArraySync();
             const user2Comments = comments
                 .where('authorId')
-                .eq(user2.id)
+                .eq(user2._id)
                 .toArraySync();
 
             expect(user1Comments).toHaveLength(1);
@@ -679,7 +679,7 @@ describe('Relationship Testing', () => {
             const postsData = createdUsers.map((user, index) => ({
                 title: `Post by ${user.name}`,
                 content: `Content ${index + 1}`,
-                authorId: user.id,
+                authorId: user._id,
             }));
 
             const createdPosts = posts.insertBulkSync(postsData);
@@ -689,14 +689,14 @@ describe('Relationship Testing', () => {
             createdUsers.forEach((user, index) => {
                 const userPosts = posts
                     .where('authorId')
-                    .eq(user.id)
+                    .eq(user._id)
                     .toArraySync();
                 expect(userPosts).toHaveLength(1);
                 expect(userPosts[0].title).toBe(`Post by ${user.name}`);
             });
 
             // Bulk delete posts
-            const postIds = createdPosts.map((p) => p.id);
+            const postIds = createdPosts.map((p) => p._id);
             const deletedCount = posts.deleteBulkSync(postIds);
             expect(deletedCount).toBe(3);
 
@@ -723,14 +723,14 @@ describe('Relationship Testing', () => {
 
             // Find all posts with invalid authors
             const allUsers = users.toArraySync();
-            const validUserIds = allUsers.map((u) => u.id);
+            const validUserIds = allUsers.map((u) => u._id);
             const allPosts = posts.toArraySync();
             const orphanPosts = allPosts.filter(
                 (p) => !validUserIds.includes(p.authorId)
             );
 
             expect(orphanPosts).toHaveLength(1);
-            expect(orphanPosts[0].id).toBe(orphanPost.id);
+            expect(orphanPosts[0]._id).toBe(orphanPost._id);
         });
 
         test('should handle duplicate relationship entries', () => {
@@ -743,7 +743,7 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'Post',
                 content: 'Content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const category = categories.insertSync({
@@ -752,37 +752,37 @@ describe('Relationship Testing', () => {
 
             // Add post to category
             const relation1 = postCategories.insertSync({
-                postId: post.id,
-                categoryId: category.id,
+                postId: post._id,
+                categoryId: category._id,
             });
 
             // Attempt to add same relationship (should be allowed but detectable)
             const relation2 = postCategories.insertSync({
-                postId: post.id,
-                categoryId: category.id,
+                postId: post._id,
+                categoryId: category._id,
             });
 
-            expect(relation1.id).not.toBe(relation2.id);
+            expect(relation1._id).not.toBe(relation2._id);
 
             // Count duplicates
             const duplicates = postCategories
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .and()
                 .where('categoryId')
-                .eq(category.id)
+                .eq(category._id)
                 .countSync();
 
             expect(duplicates).toBe(2);
 
             // Clean up one duplicate
-            postCategories.deleteSync(relation2.id);
+            postCategories.deleteSync(relation2._id);
             const remaining = postCategories
                 .where('postId')
-                .eq(post.id)
+                .eq(post._id)
                 .and()
                 .where('categoryId')
-                .eq(category.id)
+                .eq(category._id)
                 .countSync();
 
             expect(remaining).toBe(1);
@@ -808,36 +808,36 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'Tech Post 1',
                 content: 'Content 1',
-                authorId: author1.id,
+                authorId: author1._id,
                 published: true,
             });
 
             const post2 = posts.insertSync({
                 title: 'Tech Post 2',
                 content: 'Content 2',
-                authorId: author2.id,
+                authorId: author2._id,
                 published: false,
             });
 
             const post3 = posts.insertSync({
                 title: 'Science Post',
                 content: 'Science content',
-                authorId: author1.id,
+                authorId: author1._id,
                 published: true,
             });
 
             // Categorize posts
             postCategories.insertSync({
-                postId: post1.id,
-                categoryId: techCategory.id,
+                postId: post1._id,
+                categoryId: techCategory._id,
             });
             postCategories.insertSync({
-                postId: post2.id,
-                categoryId: techCategory.id,
+                postId: post2._id,
+                categoryId: techCategory._id,
             });
             postCategories.insertSync({
-                postId: post3.id,
-                categoryId: scienceCategory.id,
+                postId: post3._id,
+                categoryId: scienceCategory._id,
             });
 
             // Find published posts by authors over 25 in Tech category
@@ -845,7 +845,7 @@ describe('Relationship Testing', () => {
                 .where('age')
                 .gt(25)
                 .toArraySync()
-                .map((u) => u.id);
+                .map((u) => u._id);
             const publishedPosts = posts
                 .where('published')
                 .eq(true)
@@ -856,12 +856,12 @@ describe('Relationship Testing', () => {
 
             const techPostIds = postCategories
                 .where('categoryId')
-                .eq(techCategory.id)
+                .eq(techCategory._id)
                 .toArraySync()
                 .map((pc) => pc.postId);
 
             const result = publishedPosts.filter((p) =>
-                techPostIds.includes(p.id)
+                techPostIds.includes(p._id)
             );
             expect(result).toHaveLength(1);
             expect(result[0].title).toBe('Tech Post 1');
@@ -887,22 +887,22 @@ describe('Relationship Testing', () => {
             const post1 = posts.insertSync({
                 title: 'Alice Post 1',
                 content: 'Content by Alice',
-                authorId: user1.id,
+                authorId: user1._id,
                 published: true,
             });
 
             const post2 = posts.insertSync({
                 title: 'Bob Post 1',
                 content: 'Content by Bob',
-                authorId: user2.id,
+                authorId: user2._id,
                 published: true,
             });
 
             // INNER JOIN users and posts using where() to get QueryBuilder first
             const joinResults = users
-                .where('id')
+                .where('_id')
                 .exists() // Start with a simple condition to get QueryBuilder
-                .join('posts', 'id', 'authorId')
+                .join('posts', '_id', 'authorId')
                 .select(
                     'users.name',
                     'users.email',
@@ -937,14 +937,14 @@ describe('Relationship Testing', () => {
             posts.insertSync({
                 title: 'Alice Only Post',
                 content: 'Content',
-                authorId: user1.id,
+                authorId: user1._id,
             });
 
             // LEFT JOIN should include all users, even those without posts
             const leftJoinResults = users
-                .where('id')
+                .where('_id')
                 .exists() // Start with a simple condition to get QueryBuilder
-                .leftJoin('posts', 'id', 'authorId')
+                .leftJoin('posts', '_id', 'authorId')
                 .select('users.name', 'users.email', 'posts.title')
                 .toArraySync();
 
@@ -973,14 +973,14 @@ describe('Relationship Testing', () => {
             posts.insertSync({
                 title: 'Published Post',
                 content: 'Content',
-                authorId: user1.id,
+                authorId: user1._id,
                 published: true,
             });
 
             posts.insertSync({
                 title: 'Draft Post',
                 content: 'Draft Content',
-                authorId: user2.id,
+                authorId: user2._id,
                 published: false,
             });
 
@@ -988,7 +988,7 @@ describe('Relationship Testing', () => {
             const filteredJoinResults = users
                 .where('age')
                 .gte(25) // Start with filtering condition
-                .join('posts', 'id', 'authorId')
+                .join('posts', '_id', 'authorId')
                 .where('posts.published')
                 .eq(true) // Use table-prefixed field name
                 .select(
@@ -1014,21 +1014,21 @@ describe('Relationship Testing', () => {
             const post = posts.insertSync({
                 title: 'Multi Join Post',
                 content: 'Content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const comment = comments.insertSync({
                 content: 'Test comment',
-                postId: post.id,
-                authorId: user.id, // Comments also reference the user
+                postId: post._id,
+                authorId: user._id, // Comments also reference the user
             });
 
             // JOIN users to both posts and comments (both reference user ID)
             const multiJoinResults = users
                 .where('name')
                 .eq('Multi Join User') // Start with filtering condition
-                .join('posts', 'id', 'authorId') // Join users to posts via authorId
-                .join('comments', 'id', 'authorId') // Join users to comments via authorId
+                .join('posts', '_id', 'authorId') // Join users to posts via authorId
+                .join('comments', '_id', 'authorId') // Join users to comments via authorId
                 .select('users.name', 'posts.title', 'comments.content')
                 .toArraySync();
 
@@ -1050,13 +1050,13 @@ describe('Relationship Testing', () => {
 
             // Create collections with cascade constraints
             const userSchemaWithConstraints = z.object({
-                id: z.string().uuid(),
+                _id: z.string().uuid(),
                 name: z.string(),
                 email: z.string().email(),
             });
 
             const postSchemaWithConstraints = z.object({
-                id: z.string().uuid(),
+                _id: z.string().uuid(),
                 title: z.string(),
                 content: z.string(),
                 authorId: z.string().uuid(),
@@ -1074,7 +1074,7 @@ describe('Relationship Testing', () => {
                     constrainedFields: {
                         authorId: {
                             type: 'TEXT',
-                            foreignKey: 'users_cascade.id',
+                            foreignKey: 'users_cascade._id',
                             onDelete: 'CASCADE',
                             onUpdate: 'CASCADE',
                         },
@@ -1093,32 +1093,32 @@ describe('Relationship Testing', () => {
             const post1 = postsWithCascade.insertSync({
                 title: 'Post 1',
                 content: 'Content 1',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             const post2 = postsWithCascade.insertSync({
                 title: 'Post 2',
                 content: 'Content 2',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Verify posts exist
             expect(
-                postsWithCascade.where('authorId').eq(user.id).countSync()
+                postsWithCascade.where('authorId').eq(user._id).countSync()
             ).toBe(2);
 
             // Delete user - should cascade delete posts due to foreign key constraint
-            usersWithCascade.deleteSync(user.id);
+            usersWithCascade.deleteSync(user._id);
 
             // Verify user is deleted
-            expect(usersWithCascade.findByIdSync(user.id)).toBeNull();
+            expect(usersWithCascade.findByIdSync(user._id)).toBeNull();
 
             // Posts should be automatically deleted due to CASCADE
             expect(
-                postsWithCascade.where('authorId').eq(user.id).countSync()
+                postsWithCascade.where('authorId').eq(user._id).countSync()
             ).toBe(0);
-            expect(postsWithCascade.findByIdSync(post1.id)).toBeNull();
-            expect(postsWithCascade.findByIdSync(post2.id)).toBeNull();
+            expect(postsWithCascade.findByIdSync(post1._id)).toBeNull();
+            expect(postsWithCascade.findByIdSync(post2._id)).toBeNull();
         });
 
         test('should handle CASCADE UPDATE foreign key constraints', () => {
@@ -1131,22 +1131,22 @@ describe('Relationship Testing', () => {
             const post = postsWithCascade.insertSync({
                 title: 'Update Post',
                 content: 'Content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Verify constraint is set up correctly
-            expect(post.authorId).toBe(user.id);
+            expect(post.authorId).toBe(user._id);
 
             // The CASCADE UPDATE constraint is in place, but with UUIDs we typically don't update IDs
             // This test verifies the constraint was created properly
-            const foundPost = postsWithCascade.findByIdSync(post.id);
-            expect(foundPost?.authorId).toBe(user.id);
+            const foundPost = postsWithCascade.findByIdSync(post._id);
+            expect(foundPost?.authorId).toBe(user._id);
         });
 
         test('should handle SET NULL on delete when configured', () => {
             // Create collection with SET NULL constraint
             const commentsSchemaWithSetNull = z.object({
-                id: z.string().uuid(),
+                _id: z.string().uuid(),
                 content: z.string(),
                 authorId: z.string().uuid().optional(),
             });
@@ -1158,7 +1158,7 @@ describe('Relationship Testing', () => {
                     constrainedFields: {
                         authorId: {
                             type: 'TEXT',
-                            foreignKey: 'users_cascade.id',
+                            foreignKey: 'users_cascade._id',
                             onDelete: 'SET NULL',
                             nullable: true,
                         },
@@ -1173,17 +1173,17 @@ describe('Relationship Testing', () => {
 
             const comment = commentsWithSetNull.insertSync({
                 content: 'Comment content',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Verify comment has authorId
-            expect(comment.authorId).toBe(user.id);
+            expect(comment.authorId).toBe(user._id);
 
             // Delete user - should set authorId to NULL in comments
-            usersWithCascade.deleteSync(user.id);
+            usersWithCascade.deleteSync(user._id);
 
             // Comment should still exist but authorId should be null
-            const updatedComment = commentsWithSetNull.findByIdSync(comment.id);
+            const updatedComment = commentsWithSetNull.findByIdSync(comment._id);
             expect(updatedComment).not.toBeNull();
             expect(updatedComment?.authorId).toBeNull();
         });
@@ -1191,7 +1191,7 @@ describe('Relationship Testing', () => {
         test('should handle RESTRICT constraint (prevent deletion)', () => {
             // Create collection with RESTRICT constraint
             const restrictPostsSchema = z.object({
-                id: z.string().uuid(),
+                _id: z.string().uuid(),
                 title: z.string(),
                 authorId: z.string().uuid(),
             });
@@ -1203,7 +1203,7 @@ describe('Relationship Testing', () => {
                     constrainedFields: {
                         authorId: {
                             type: 'TEXT',
-                            foreignKey: 'users_cascade.id',
+                            foreignKey: 'users_cascade._id',
                             onDelete: 'RESTRICT',
                         },
                     },
@@ -1217,13 +1217,13 @@ describe('Relationship Testing', () => {
 
             postsWithRestrict.insertSync({
                 title: 'Restricted Post',
-                authorId: user.id,
+                authorId: user._id,
             });
 
             // Attempting to delete user should be prevented by RESTRICT constraint
             // Note: SQLite will throw an error when RESTRICT constraint is violated
             expect(() => {
-                usersWithCascade.deleteSync(user.id);
+                usersWithCascade.deleteSync(user._id);
             }).toThrow(); // Should throw due to foreign key constraint violation
         });
     });
@@ -1255,7 +1255,7 @@ describe('Relationship Testing', () => {
                         posts.insertSync({
                             title: `Post ${j + 1} by ${user.name}`,
                             content: `Content for post ${j + 1}`,
-                            authorId: user.id,
+                            authorId: user._id,
                             published: Math.random() > 0.5,
                         })
                     );
@@ -1296,7 +1296,7 @@ describe('Relationship Testing', () => {
                 posts.insertSync({
                     title: `Post ${i}`,
                     content: `Content ${i}`,
-                    authorId: author.id,
+                    authorId: author._id,
                     published: i % 2 === 0,
                 });
             }
@@ -1306,14 +1306,14 @@ describe('Relationship Testing', () => {
             // Test indexed lookup by authorId
             const authorPosts = posts
                 .where('authorId')
-                .eq(author.id)
+                .eq(author._id)
                 .toArraySync();
             expect(authorPosts).toHaveLength(postCount);
 
             // Test compound filtering
             const publishedAuthorPosts = posts
                 .where('authorId')
-                .eq(author.id)
+                .eq(author._id)
                 .and()
                 .where('published')
                 .eq(true)

--- a/test/schema-constraints.test.ts
+++ b/test/schema-constraints.test.ts
@@ -20,7 +20,7 @@ describe('Schema Constraints', () => {
     describe('Unique Constraints', () => {
         it('should enforce unique constraints on single fields', () => {
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 email: z.string().email(),
                 username: z.string(),
                 age: z.number().optional(),
@@ -74,7 +74,7 @@ describe('Schema Constraints', () => {
 
         it('should allow null values in unique fields', () => {
             const profileSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 username: z.string(),
                 bio: z.string().nullable(),
             });
@@ -115,7 +115,7 @@ describe('Schema Constraints', () => {
 
         it('should enforce unique constraints on updates', () => {
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 email: z.string().email(),
                 username: z.string(),
             });
@@ -138,17 +138,17 @@ describe('Schema Constraints', () => {
 
             // Updating user2's email to user1's email should fail
             expect(() => {
-                users.putSync(user2.id, { email: 'john@example.com' });
+                users.putSync(user2._id, { email: 'john@example.com' });
             }).toThrow(UniqueConstraintError);
 
             // Updating user2's email to a new unique value should succeed
-            const updatedUser2 = users.putSync(user2.id, {
+            const updatedUser2 = users.putSync(user2._id, {
                 email: 'jane.smith@example.com',
             });
             expect(updatedUser2.email).toBe('jane.smith@example.com');
 
             // Updating user1's email to the same value should succeed (no change)
-            const updatedUser1 = users.putSync(user1.id, {
+            const updatedUser1 = users.putSync(user1._id, {
                 email: 'john@example.com',
             });
             expect(updatedUser1.email).toBe('john@example.com');
@@ -158,7 +158,7 @@ describe('Schema Constraints', () => {
     describe('Composite Unique Constraints', () => {
         it('should enforce composite unique constraints', () => {
             const membershipSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 userId: z.string(),
                 organizationId: z.string(),
                 role: z.string(),
@@ -210,12 +210,12 @@ describe('Schema Constraints', () => {
     describe('Foreign Key Constraints', () => {
         it.skip('should validate foreign key references on insert', () => {
             const organizationSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
             });
 
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 organizationId: z.string(),
             });
@@ -227,7 +227,7 @@ describe('Schema Constraints', () => {
             const users = db.collection('users', userSchema, {
                 constraints: {
                     constraints: {
-                        organizationId: foreignKey('organizations', 'id'),
+                        organizationId: foreignKey('organizations', '_id'),
                     },
                 },
             });
@@ -240,10 +240,10 @@ describe('Schema Constraints', () => {
             // User with valid foreign key should succeed
             const user = users.insertSync({
                 name: 'John Doe',
-                organizationId: org.id,
+                organizationId: org._id,
             });
 
-            expect(user.organizationId).toBe(org.id);
+            expect(user.organizationId).toBe(org._id);
 
             // User with invalid foreign key should fail
             expect(() => {
@@ -256,12 +256,12 @@ describe('Schema Constraints', () => {
 
         it.skip('should validate foreign key references on update', () => {
             const organizationSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
             });
 
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 organizationId: z.string(),
             });
@@ -273,7 +273,7 @@ describe('Schema Constraints', () => {
             const users = db.collection('users', userSchema, {
                 constraints: {
                     constraints: {
-                        organizationId: foreignKey('organizations', 'id'),
+                        organizationId: foreignKey('organizations', '_id'),
                     },
                 },
             });
@@ -285,18 +285,18 @@ describe('Schema Constraints', () => {
             // Create user
             const user = users.insertSync({
                 name: 'John Doe',
-                organizationId: org1.id,
+                organizationId: org1._id,
             });
 
             // Update to valid foreign key should succeed
-            const updatedUser = users.putSync(user.id, {
-                organizationId: org2.id,
+            const updatedUser = users.putSync(user._id, {
+                organizationId: org2._id,
             });
-            expect(updatedUser.organizationId).toBe(org2.id);
+            expect(updatedUser.organizationId).toBe(org2._id);
 
             // Update to invalid foreign key should fail
             expect(() => {
-                users.putSync(user.id, { organizationId: 'invalid-org-id' });
+                users.putSync(user._id, { organizationId: 'invalid-org-id' });
             }).toThrow(ValidationError);
         });
     });
@@ -305,7 +305,7 @@ describe('Schema Constraints', () => {
         it.skip('should enforce check constraints', async () => {
             // Skipping for now - CHECK constraints on JSON fields are complex in SQLite
             const productSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 price: z.number(),
                 category: z.string(),
@@ -356,7 +356,7 @@ describe('Schema Constraints', () => {
     describe('Index Creation', () => {
         it('should create indexes for better query performance', () => {
             const eventSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 createdAt: z.date(),
                 userId: z.string(),
@@ -401,7 +401,7 @@ describe('Schema Constraints', () => {
     describe('Multiple Constraints', () => {
         it('should handle multiple constraints on the same field', () => {
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 email: z.string().email(),
                 age: z.number(),
             });
@@ -447,7 +447,7 @@ describe('Schema Constraints', () => {
     describe('Constraint Error Handling', () => {
         it('should provide meaningful error messages', () => {
             const userSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 email: z.string().email(),
                 username: z.string(),
             });

--- a/test/tables.test.ts
+++ b/test/tables.test.ts
@@ -4,7 +4,7 @@ import { createDB } from '../src/index.js';
 import { unique, foreignKey, index } from '../src/schema-constraints.js';
 
 const userSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int().optional(),
@@ -14,7 +14,7 @@ const userSchema = z.object({
 });
 
 const postSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     title: z.string(),
     content: z.string(),
     authorId: z.string().uuid(),
@@ -23,7 +23,7 @@ const postSchema = z.object({
 });
 
 const categorySchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     description: z.string().optional(),
     parentId: z.string().uuid().optional(),
@@ -158,12 +158,12 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             // Verify using raw SQL
             const rawUserRows = await db.query(
                 'SELECT * FROM users WHERE _id = ?',
-                [user.id]
+                [user._id]
             );
             expect(rawUserRows.length).toBe(1);
 
             const rawUser = rawUserRows[0];
-            expect(rawUser._id).toBe(user.id);
+            expect(rawUser._id).toBe(user._id);
             expect(rawUser.email).toBe('john@example.com'); // Constrained field
 
             // Check doc column contains the full document
@@ -179,19 +179,19 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             const post = await posts.insert({
                 title: 'My First Post',
                 content: 'Hello world!',
-                authorId: user.id,
+                authorId: user._id,
                 viewCount: 5,
             });
 
             // Verify post using raw SQL
             const rawPostRows = await db.query(
                 'SELECT * FROM posts WHERE _id = ?',
-                [post.id]
+                [post._id]
             );
             expect(rawPostRows.length).toBe(1);
 
             const rawPost = rawPostRows[0];
-            expect(rawPost.authorId).toBe(user.id); // Constrained field
+            expect(rawPost.authorId).toBe(user._id); // Constrained field
 
             const parsedPostData = JSON.parse(rawPost.doc);
             expect(parsedPostData.title).toBe('My First Post');
@@ -304,7 +304,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             });
 
             // Update using API
-            const updatedUser = await users.put(user.id, {
+            const updatedUser = await users.put(user._id, {
                 name: 'Updated User',
                 age: 26,
             });
@@ -316,7 +316,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             // Verify using raw SQL
             const rawUserRows = await db.query(
                 'SELECT * FROM users WHERE _id = ?',
-                [user.id]
+                [user._id]
             );
             expect(rawUserRows.length).toBe(1);
 
@@ -353,7 +353,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             expect(initialCount[0].count).toBe(3);
 
             // Delete one user using API
-            const deleteResult = await users.delete(users2.id);
+            const deleteResult = await users.delete(users2._id);
             expect(deleteResult).toBe(true);
 
             // Verify using raw SQL
@@ -367,7 +367,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             // Verify deleted user is gone
             const deletedUserRows = await db.query(
                 'SELECT * FROM users WHERE _id = ?',
-                [users2.id]
+                [users2._id]
             );
             expect(deletedUserRows.length).toBe(0);
         });
@@ -387,35 +387,35 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             const post1 = await posts.insert({
                 title: 'Post by Author 1',
                 content: 'Content 1',
-                authorId: author1.id,
+                authorId: author1._id,
                 viewCount: 10,
             });
 
             const post2 = await posts.insert({
                 title: 'Another Post by Author 1',
                 content: 'Content 2',
-                authorId: author1.id,
+                authorId: author1._id,
                 viewCount: 5,
             });
 
             const post3 = await posts.insert({
                 title: 'Post by Author 2',
                 content: 'Content 3',
-                authorId: author2.id,
+                authorId: author2._id,
                 viewCount: 15,
             });
 
             // Query posts by author using API
             const author1Posts = await posts
                 .where('authorId')
-                .eq(author1.id)
+                .eq(author1._id)
                 .toArray();
             expect(author1Posts.length).toBe(2);
 
             // Query posts by author using raw SQL
             const author1PostsSQL = await db.query(
                 'SELECT * FROM posts WHERE authorId = ?',
-                [author1.id]
+                [author1._id]
             );
             expect(author1PostsSQL.length).toBe(2);
 
@@ -468,12 +468,12 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             // Verify using raw SQL
             const rawUserRows = db.querySync(
                 'SELECT * FROM users WHERE _id = ?',
-                [user.id]
+                [user._id]
             );
             expect(rawUserRows.length).toBe(1);
 
             const rawUser = rawUserRows[0];
-            expect(rawUser._id).toBe(user.id);
+            expect(rawUser._id).toBe(user._id);
             expect(rawUser.email).toBe('john.sync@example.com');
 
             // Check doc column contains the full document
@@ -583,7 +583,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             });
 
             // Update using sync API
-            const updatedUser = users.putSync(user.id, {
+            const updatedUser = users.putSync(user._id, {
                 name: 'Updated User Sync',
                 age: 26,
             });
@@ -595,7 +595,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             // Verify using raw SQL
             const rawUserRows = db.querySync(
                 'SELECT * FROM users WHERE _id = ?',
-                [user.id]
+                [user._id]
             );
             expect(rawUserRows.length).toBe(1);
 
@@ -628,7 +628,7 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             expect(initialCount[0].count).toBe(3);
 
             // Delete one user using sync API
-            const deleteResult = users.deleteSync(users2.id);
+            const deleteResult = users.deleteSync(users2._id);
             expect(deleteResult).toBe(true);
 
             // Verify using raw SQL
@@ -655,28 +655,28 @@ describe('Tables: skibbaDB API vs Raw SQL Verification', () => {
             const post1 = posts.insertSync({
                 title: 'Post by Author 1 Sync',
                 content: 'Content 1',
-                authorId: author1.id,
+                authorId: author1._id,
                 viewCount: 10,
             });
 
             const post2 = posts.insertSync({
                 title: 'Another Post by Author 1 Sync',
                 content: 'Content 2',
-                authorId: author1.id,
+                authorId: author1._id,
                 viewCount: 5,
             });
 
             // Query posts by author using sync API
             const author1Posts = posts
                 .where('authorId')
-                .eq(author1.id)
+                .eq(author1._id)
                 .toArraySync();
             expect(author1Posts.length).toBe(2);
 
             // Query posts by author using raw SQL
             const author1PostsSQL = db.querySync(
                 'SELECT * FROM posts WHERE authorId = ?',
-                [author1.id]
+                [author1._id]
             );
             expect(author1PostsSQL.length).toBe(2);
 

--- a/test/test-db.mjs
+++ b/test/test-db.mjs
@@ -18,7 +18,7 @@ async function testDatabase() {
         console.log(`✅ ${driver} database created successfully`);
 
         const schema = z.object({
-            id: z.string().optional(),
+            _id: z.string().optional(),
             title: z.string(),
             completed: z.boolean().default(false),
         });

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -6,7 +6,7 @@ import { ValidationError, DatabaseError } from '../src/errors';
 describe('Transactions', () => {
     let db: ReturnType<typeof createDB>;
     const userSchema = z.object({
-        id: z
+        _id: z
             .string()
             .uuid()
             .default(() => crypto.randomUUID()),
@@ -16,7 +16,7 @@ describe('Transactions', () => {
         createdAt: z.date().default(() => new Date()),
     });
     const postSchema = z.object({
-        id: z
+        _id: z
             .string()
             .uuid()
             .default(() => crypto.randomUUID()),
@@ -40,7 +40,7 @@ describe('Transactions', () => {
             const post = await posts.insert({
                 title: 'Hello',
                 content: 'World',
-                authorId: user.id!,
+                authorId: user._id!,
             });
             return { user, post };
         });
@@ -85,7 +85,7 @@ describe('Transactions', () => {
                 name: 'Jane',
                 email: 'jane@example.com',
             });
-            return user.id;
+            return user._id;
         });
         expect(typeof id).toBe('string');
         expect(users.findById(id!)).toBeTruthy();
@@ -258,7 +258,7 @@ describe('Transactions', () => {
             await posts.insert({
                 title: 'T',
                 content: 'C',
-                authorId: author.id!,
+                authorId: author._id!,
             });
             expect(await users.toArray()).toHaveLength(2);
             expect(await posts.toArray()).toHaveLength(1);

--- a/test/update-performance-analysis.test.ts
+++ b/test/update-performance-analysis.test.ts
@@ -4,20 +4,20 @@ import { unique, foreignKey, index } from '../src/schema-constraints.js';
 
 // Test schemas for different complexity levels
 const simpleSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     score: z.number(),
 });
 
 const constrainedSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     email: z.string().email(),
     username: z.string(),
     score: z.number(),
 });
 
 const complexSchema = z.object({
-    id: z.string().uuid(),
+    _id: z.string().uuid(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -78,7 +78,7 @@ async function analyzeUpdatePerformance() {
     }));
 
     simpleCollection.insertBulk(simpleData);
-    const simpleIds = simpleCollection.toArraySync().map((doc) => doc.id);
+    const simpleIds = simpleCollection.toArraySync().map((doc) => doc._id);
 
     const simpleUpdateResult = benchmark(
         'Simple Updates (No Constraints)',
@@ -115,7 +115,7 @@ async function analyzeUpdatePerformance() {
     constrainedCollection.insertBulk(constrainedData);
     const constrainedIds = constrainedCollection
         .toArraySync()
-        .map((doc) => doc.id);
+        .map((doc) => doc._id);
 
     const constrainedUpdateResult = benchmark(
         'Updates with Unique Constraints',
@@ -162,7 +162,7 @@ async function analyzeUpdatePerformance() {
     }));
 
     complexCollection.insertBulk(complexData);
-    const complexIds = complexCollection.toArraySync().map((doc) => doc.id);
+    const complexIds = complexCollection.toArraySync().map((doc) => doc._id);
 
     const complexUpdateResult = benchmark(
         'Complex Updates (Schema + Constraints)',

--- a/test/upgrade-functions-simple.test.ts
+++ b/test/upgrade-functions-simple.test.ts
@@ -12,7 +12,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should run upgrade function on new collection', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
         });
@@ -51,7 +51,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should run seed function for new collection', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             role: z.string(),
         });
@@ -80,7 +80,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should skip conditional upgrade when condition is false', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
@@ -106,7 +106,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should run multiple upgrade functions in sequence', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
             fullName: z.string().optional(),
@@ -125,7 +125,7 @@ describe('Upgrade Functions - Simple Tests', () => {
                     executionOrder.push(3);
                     const users = await collection.toArray();
                     for (const user of users) {
-                        await collection.put(user.id, { ...user, fullName: user.name });
+                        await collection.put(user._id, { ...user, fullName: user.name });
                     }
                 }
             }
@@ -143,7 +143,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should handle upgrade function errors gracefully', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
@@ -172,7 +172,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
         try {
             const UserSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
             });
 
@@ -206,7 +206,7 @@ describe('Upgrade Functions - Simple Tests', () => {
 
     it('should provide upgrade context with SQL access', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             nameLength: z.number().optional(),
         });

--- a/test/upgrade-functions.test.ts
+++ b/test/upgrade-functions.test.ts
@@ -12,7 +12,7 @@ describe('Upgrade Functions', () => {
 
     it('should run simple upgrade function', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
         });
@@ -57,7 +57,7 @@ describe('Upgrade Functions', () => {
 
     it('should run conditional upgrade function', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             isActive: z.boolean().optional(),
         });
@@ -79,7 +79,7 @@ describe('Upgrade Functions', () => {
                         upgradeRan = true;
                         const users = await collection.toArray();
                         for (const user of users) {
-                            await collection.put(user.id, {
+                            await collection.put(user._id, {
                                 ...user,
                                 isActive: true,
                             });
@@ -104,7 +104,7 @@ describe('Upgrade Functions', () => {
 
     it('should skip conditional upgrade when condition is false', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             processed: z.boolean().optional(),
         });
@@ -131,7 +131,7 @@ describe('Upgrade Functions', () => {
 
     it('should run multiple upgrade functions in sequence', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             email: z.string().optional(),
             fullName: z.string().optional(),
@@ -147,14 +147,14 @@ describe('Upgrade Functions', () => {
                     const users = await collection.toArray();
                     for (const user of users) {
                         const email = `${user.name.toLowerCase()}@example.com`;
-                        await collection.put(user.id, { ...user, email });
+                        await collection.put(user._id, { ...user, email });
                     }
                 },
                 3: async (collection: any) => {
                     executionOrder.push(3);
                     const users = await collection.toArray();
                     for (const user of users) {
-                        await collection.put(user.id, {
+                        await collection.put(user._id, {
                             ...user,
                             fullName: user.name,
                         });
@@ -178,12 +178,12 @@ describe('Upgrade Functions', () => {
 
     it('should provide upgrade context with database access', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
         const ProfileSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             userId: z.string(),
             bio: z.string(),
         });
@@ -207,7 +207,7 @@ describe('Upgrade Functions', () => {
                     const users = await collection.toArray();
                     for (const user of users) {
                         await profiles.insert({
-                            userId: user.id,
+                            userId: user._id,
                             bio: `Profile for ${user.name}`,
                         });
                     }
@@ -233,12 +233,12 @@ describe('Upgrade Functions', () => {
         const profiles = db.collection('profiles');
         const profilesData = await profiles.toArray();
         expect(profilesData.length).toBe(1);
-        expect(profilesData[0].userId).toBe(insertedUser.id);
+        expect(profilesData[0].userId).toBe(insertedUser._id);
     });
 
     it('should run upgrade functions with SQL access', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             nameLength: z.number().optional(),
         });
@@ -271,7 +271,7 @@ describe('Upgrade Functions', () => {
 
     it('should run seed function for new collections', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             role: z.string(),
         });
@@ -309,7 +309,7 @@ describe('Upgrade Functions', () => {
 
     it('should handle upgrade function errors gracefully', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
         });
 
@@ -341,7 +341,7 @@ describe('Upgrade Functions', () => {
 
         try {
             const UserSchema = z.object({
-                id: z.string(),
+                _id: z.string(),
                 name: z.string(),
                 processed: z.boolean().optional(),
             });
@@ -376,7 +376,7 @@ describe('Upgrade Functions', () => {
 
     it('should handle transaction rollback on upgrade failure', async () => {
         const UserSchema = z.object({
-            id: z.string(),
+            _id: z.string(),
             name: z.string(),
             processed: z.boolean().optional(),
         });

--- a/test/upsert-benchmark.test.ts
+++ b/test/upsert-benchmark.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { createDB } from '../index';
 
 const testSchema = z.object({
-    id: z.string().optional(),
+    _id: z.string().optional(),
     name: z.string(),
     email: z.string().email(),
     score: z.number(),
@@ -119,7 +119,7 @@ test('Upsert Benchmark - Comprehensive Sync vs Async', async () => {
     }));
 
     const setupDocs = await collection.insertBulk(setupData);
-    const existingIds = setupDocs.map((doc) => doc.id!);
+    const existingIds = setupDocs.map((doc) => doc._id!);
 
     // Generate test data: 50% updates (existing IDs) + 50% inserts (new IDs)
     const newIds = Array.from({ length: benchmarkCount }, () =>
@@ -435,8 +435,8 @@ test('Upsert Benchmark - Comprehensive Sync vs Async', async () => {
         score: 200,
     });
 
-    expect(syncUpsertResult.id).toBe(testId);
-    expect(asyncUpsertResult.id).toBe(testId);
+    expect(syncUpsertResult._id).toBe(testId);
+    expect(asyncUpsertResult._id).toBe(testId);
     expect(asyncUpsertResult.score).toBe(200);
 
     console.log(`\n✅ All benchmark tests completed successfully!`);
@@ -458,7 +458,7 @@ test('Upsert Correctness - Sync vs Async Equivalence', async () => {
     // Test 1: Insert via sync upsert
     const syncInsertResult = collection.upsertSync(testId, insertDoc);
     console.log(
-        `Sync insert result: ID=${syncInsertResult.id}, score=${syncInsertResult.score}`
+        `Sync insert result: ID=${syncInsertResult._id}, score=${syncInsertResult.score}`
     );
 
     // Test 2: Update via async upsert
@@ -467,15 +467,15 @@ test('Upsert Correctness - Sync vs Async Equivalence', async () => {
         score: 100,
     });
     console.log(
-        `Async update result: ID=${asyncUpdateResult.id}, score=${asyncUpdateResult.score}`
+        `Async update result: ID=${asyncUpdateResult._id}, score=${asyncUpdateResult.score}`
     );
 
     // Test 3: Verify final state
     const finalDoc = collection.findByIdSync(testId);
-    console.log(`Final state: ID=${finalDoc?.id}, score=${finalDoc?.score}`);
+    console.log(`Final state: ID=${finalDoc?._id}, score=${finalDoc?.score}`);
 
-    expect(syncInsertResult.id).toBe(testId);
-    expect(asyncUpdateResult.id).toBe(testId);
+    expect(syncInsertResult._id).toBe(testId);
+    expect(asyncUpdateResult._id).toBe(testId);
     expect(finalDoc?.score).toBe(100);
     expect(finalDoc?.name).toBe('Equivalence Test');
 

--- a/test/upsert.test.ts
+++ b/test/upsert.test.ts
@@ -4,20 +4,20 @@ import { createDB } from '../index';
 
 // Test schemas for different complexity levels
 const simpleSchema = z.object({
-    id: z.string().optional(),
+    _id: z.string().optional(),
     name: z.string(),
     score: z.number(),
 });
 
 const constrainedSchema = z.object({
-    id: z.string().optional(),
+    _id: z.string().optional(),
     email: z.string().email(),
     username: z.string(),
     score: z.number(),
 });
 
 const complexSchema = z.object({
-    id: z.string().optional(),
+    _id: z.string().optional(),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -77,7 +77,7 @@ async function analyzeUpsertPerformance() {
         score: Math.random() * 1000,
     }));
     const preInserted = await simpleCollection.insertBulk(preData);
-    const existingIds = preInserted.map((doc) => doc.id!);
+    const existingIds = preInserted.map((doc) => doc._id!);
 
     // Generate test data: 500 existing IDs (updates) + 500 new IDs (inserts)
     const newIds = Array.from({ length: 500 }, () => crypto.randomUUID());
@@ -127,7 +127,7 @@ async function analyzeUpsertPerformance() {
     const constrainedPreInserted = await constrainedCollection.insertBulk(
         constrainedPreData
     );
-    const constrainedExistingIds = constrainedPreInserted.map((doc) => doc.id!);
+    const constrainedExistingIds = constrainedPreInserted.map((doc) => doc._id!);
 
     const constrainedNewIds = Array.from({ length: 500 }, () =>
         crypto.randomUUID()
@@ -173,7 +173,7 @@ async function analyzeUpsertPerformance() {
     const complexPreInserted = await complexCollection.insertBulk(
         complexPreData
     );
-    const complexExistingIds = complexPreInserted.map((doc) => doc.id!);
+    const complexExistingIds = complexPreInserted.map((doc) => doc._id!);
 
     const complexNewIds = Array.from({ length: 500 }, () =>
         crypto.randomUUID()
@@ -308,7 +308,7 @@ test('Upsert Performance Analysis > should test basic upsert functionality', asy
             score: 100,
         });
 
-        expect(insertResult.id).toBe(testId);
+        expect(insertResult._id).toBe(testId);
         expect(insertResult.name).toBe('Test User');
         expect(insertResult.score).toBe(100);
 
@@ -318,7 +318,7 @@ test('Upsert Performance Analysis > should test basic upsert functionality', asy
             score: 200,
         });
 
-        expect(updateResult.id).toBe(testId);
+        expect(updateResult._id).toBe(testId);
         expect(updateResult.name).toBe('Updated User');
         expect(updateResult.score).toBe(200);
 
@@ -337,7 +337,7 @@ test('Upsert Performance Analysis > should test bulk upsert functionality', asyn
         const collection = db.collection('bulk_test', simpleSchema);
 
         const testData = Array.from({ length: 100 }, (_, i) => ({
-            id: crypto.randomUUID(),
+            _id: crypto.randomUUID(),
             doc: {
                 name: `Bulk User ${i}`,
                 score: i * 10,

--- a/test/upsert.test.ts
+++ b/test/upsert.test.ts
@@ -4,20 +4,20 @@ import { createDB } from '../index';
 
 // Test schemas for different complexity levels
 const simpleSchema = z.object({
-    _id: z.string().optional(),
+    _id: z.string().default(() => crypto.randomUUID()),
     name: z.string(),
     score: z.number(),
 });
 
 const constrainedSchema = z.object({
-    _id: z.string().optional(),
+    _id: z.string().default(() => crypto.randomUUID()),
     email: z.string().email(),
     username: z.string(),
     score: z.number(),
 });
 
 const complexSchema = z.object({
-    _id: z.string().optional(),
+    _id: z.string().default(() => crypto.randomUUID()),
     name: z.string(),
     email: z.string().email(),
     age: z.number().int(),
@@ -100,7 +100,7 @@ async function analyzeUpsertPerformance() {
     // Test 2: Simple upsert bulk operations
     console.log('2. Testing simple upsert bulk operations...');
     const bulkUpsertData = allIds.map((id, i) => ({
-        id,
+        _id: id,
         doc: {
             name: `Bulk User ${i}`,
             score: i * 5,
@@ -127,7 +127,9 @@ async function analyzeUpsertPerformance() {
     const constrainedPreInserted = await constrainedCollection.insertBulk(
         constrainedPreData
     );
-    const constrainedExistingIds = constrainedPreInserted.map((doc) => doc._id!);
+    const constrainedExistingIds = constrainedPreInserted.map(
+        (doc) => doc._id!
+    );
 
     const constrainedNewIds = Array.from({ length: 500 }, () =>
         crypto.randomUUID()
@@ -246,7 +248,7 @@ async function analyzeUpsertPerformance() {
         });
 
         const mixedBulkData = newIds.slice(250, 500).map((id, i) => ({
-            id,
+            _id: id,
             doc: {
                 name: `Bulk Mixed User ${i}`,
                 score: i * 18,
@@ -349,8 +351,8 @@ test('Upsert Performance Analysis > should test bulk upsert functionality', asyn
         expect(insertResults).toHaveLength(100);
 
         // Test bulk upsert (all updates)
-        const updateData = testData.map(({ id }, i) => ({
-            id,
+        const updateData = testData.map(({ _id }, i) => ({
+            _id,
             doc: {
                 name: `Updated Bulk User ${i}`,
                 score: i * 20,

--- a/test/vector-search.test.ts
+++ b/test/vector-search.test.ts
@@ -28,7 +28,7 @@ async function getEmbedding(text: string): Promise<number[]> {
 
 // Define schema with vector field
 const DocumentSchema = z.object({
-    id: z.string(),
+    _id: z.string(),
     title: z.string(),
     content: z.string(),
     embedding: z.array(z.number()), // This will be treated as a vector field
@@ -40,7 +40,7 @@ type Document = z.infer<typeof DocumentSchema>;
 const documentCollection: CollectionSchema<Document> = {
     name: 'documents',
     schema: DocumentSchema,
-    primaryKey: 'id',
+    primaryKey: '_id',
     constrainedFields: {
         embedding: {
             type: 'VECTOR',
@@ -103,7 +103,7 @@ drivers.forEach(({ name, config }) => {
         beforeEach(async () => {
             db = new Database(config);
             collection = db.collection('documents', DocumentSchema, {
-                primaryKey: 'id',
+                primaryKey: '_id',
                 constrainedFields: {
                     'embedding': {
                         type: 'VECTOR',
@@ -163,7 +163,7 @@ drivers.forEach(({ name, config }) => {
             expect(results).toHaveLength(2);
             expect(results[0].distance).toBeDefined();
             expect(typeof results[0].distance).toBe('number');
-            expect(results[0].id).toBeDefined();
+            expect(results[0]._id).toBeDefined();
             // Should return tech-related documents first
             expect(['Document 1', 'Document 4']).toContain(
                 results[0].document.title
@@ -256,7 +256,7 @@ drivers.forEach(({ name, config }) => {
             const newEmbedding = await getOrCreateEmbedding(
                 'updated content about machine learning algorithms'
             );
-            const updatedDoc = await collection.put(doc.id, {
+            const updatedDoc = await collection.put(doc._id, {
                 ...doc,
                 content: 'updated content about machine learning algorithms',
                 embedding: newEmbedding,
@@ -272,7 +272,7 @@ drivers.forEach(({ name, config }) => {
             };
 
             const results = await collection.vectorSearch(searchOptions);
-            expect(results[0].document.id).toBe(doc.id);
+            expect(results[0].document._id).toBe(doc._id);
         });
 
         test('should handle vector deletions', async () => {
@@ -280,7 +280,7 @@ drivers.forEach(({ name, config }) => {
             const initialCount = docs.length;
 
             // Delete a document
-            await collection.delete(docs[0].id);
+            await collection.delete(docs[0]._id);
 
             // Verify it's gone from regular queries
             const remainingDocs = await collection.toArray();
@@ -295,7 +295,7 @@ drivers.forEach(({ name, config }) => {
 
             const results = await collection.vectorSearch(searchOptions);
             const foundDeleted = results.find(
-                (r) => r.document.id === docs[0].id
+                (r) => r.document._id === docs[0]._id
             );
             expect(foundDeleted).toBeUndefined();
         });

--- a/test/vector-simple.test.ts
+++ b/test/vector-simple.test.ts
@@ -5,7 +5,7 @@ import type { CollectionSchema, VectorSearchOptions } from '../src/types';
 
 // Simple test with small vectors to avoid API calls
 const DocumentSchema = z.object({
-    id: z.string(),
+    _id: z.string(),
     title: z.string(),
     embedding: z.array(z.number()),
 });
@@ -15,7 +15,7 @@ type Document = z.infer<typeof DocumentSchema>;
 const documentCollection: CollectionSchema<Document> = {
     name: 'documents',
     schema: DocumentSchema,
-    primaryKey: 'id',
+    primaryKey: '_id',
     constrainedFields: {
         'embedding': {
             type: 'VECTOR',
@@ -47,7 +47,7 @@ describe('Vector Search Basic Tests', () => {
     beforeEach(async () => {
         db = new Database({ driver: 'bun', memory: true });
         collection = db.collection('documents', DocumentSchema, {
-            primaryKey: 'id',
+            primaryKey: '_id',
             constrainedFields: {
                 'embedding': {
                     type: 'VECTOR',


### PR DESCRIPTION
## Summary
- unify Collection methods to expect `_id`
- adjust SQL translator and schema generator for `_id`
- update plugins and example type helpers
- convert tests to the `_id` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841db98945c832781cfb397ef9c627d